### PR TITLE
Fixing Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
+      # Necessary because there is a currently a dependency audio-decode > av > speaker which fails to be built on windows
+      # *But* it is an optional depedency so we don't actually need to install thankfully
       - run: npm ci --no-optional
       - run: npm run install-app-deps
 

--- a/changelogs/0.2.3-CHANGELOG.md
+++ b/changelogs/0.2.3-CHANGELOG.md
@@ -1,0 +1,9 @@
+### Added
+- We are now catching and logging unhandled errors and rejected promises!
+
+### Changed
+- The `Application` menu in the menubar will now show `DAWG` on Windows and Linux (this was done automatically on MacOS).
+
+### Fix
+- Extension loading now working on Windows. Previously a path issue caused some extensions to not be loaded.
+- Fixed menubar and context menus in Windows. Previously small discrepancies in the behavior of these items between operating systems prevented them from functioning properly.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "DAWG",
   "version": "0.2.2",
   "private": true,
-  "author": "DAWG People <dawgpeople@gmail.com>",
+  "author": "Jacob Smith <jacob.smith@unb.ca>",
   "scripts": {
     "serve": "vue-cli-service electron:serve",
     "build": "vue-cli-service electron:build",

--- a/src/background.ts
+++ b/src/background.ts
@@ -39,7 +39,8 @@ function createWindow() {
 
   // Make the menu initially not visible
   // Basically, get rid of the default menu
-  win.setMenuBarVisibility(false);
+  // TODO what happens on macos??
+  // win.setMenuBarVisibility(false);
 
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     // Load the url of the dev server if in development mode

--- a/src/background.ts
+++ b/src/background.ts
@@ -44,11 +44,6 @@ function createWindow() {
     },
   });
 
-  // Make the menu initially not visible
-  // Basically, get rid of the default menu
-  // TODO what happens on macos??
-  // win.setMenuBarVisibility(false);
-
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     // Load the url of the dev server if in development mode
     // userAgent: Chrome fixes the following issues

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,7 +10,14 @@ import { isDevelopment } from './lib/electron/environment';
 import eLog from 'electron-log';
 
 eLog.transports.console.level = false;
-eLog.transports.file.level = false;
+eLog.transports.file.level = 'info';
+
+eLog.catchErrors({
+  showDialog: false,
+  onError: (e) => {
+    eLog.error(`${e.name}: ${e.message}`);
+  },
+});
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.

--- a/src/core/project.ts
+++ b/src/core/project.ts
@@ -45,7 +45,7 @@ import { createExtension } from '@/lib/framework';
 import { commands } from '@/core/commands';
 import { computed } from '@vue/composition-api';
 
-const logger = getLogger('project', { level: 'debug' });
+const logger = getLogger('project');
 
 const DG = 'dg';
 const FILTERS = [{ name: 'DAWG Files', extensions: [DG] }];

--- a/src/lib/electron/context.ts
+++ b/src/lib/electron/context.ts
@@ -4,7 +4,7 @@ interface Options {
   showInspectElement?: boolean;
 }
 
-const webContents = (win: any) => win.webContents || win.getWebContents();
+const webContents = (win: electron.BrowserWindow) => win.webContents;
 
 const decorateMenuItem = (menuItem: any) => {
   return (options: any = {}) => {
@@ -31,9 +31,9 @@ const removeUnusedMenuItems = (menuTemplate: any[]) => {
     });
 };
 
-const create = (win: any, options: Options) => {
-  webContents(win).on('context-menu', (event: any, props: any) => {
-    const {editFlags} = props;
+const create = (win: electron.BrowserWindow, options: Options) => {
+  win.webContents.on('context-menu', (_, props: any) => {
+    const { editFlags } = props;
     const hasText = props.selectionText.trim().length > 0;
     const isLink = Boolean(props.linkURL);
     const can = (type: any) => editFlags[`can${type}`] && hasText;
@@ -99,7 +99,7 @@ const create = (win: any, options: Options) => {
         id: 'inspect',
         label: 'Inspect Element',
         click() {
-          win.inspectElement(props.x, props.y);
+          win.webContents.inspectElement(props.x, props.y);
 
           if (webContents(win).isDevToolsOpened()) {
             webContents(win).devToolsWebContents.focus();
@@ -141,8 +141,8 @@ const create = (win: any, options: Options) => {
 			context-menu should open in.
 			When this is being called from a webView, we can't use win as this
 			would refere to the webView which is not allowed to render a popup menu.
-			*/
-      menu.popup(electron.remote ? electron.remote.getCurrentWindow() : win);
+      */
+      menu.popup();
     }
   });
 };

--- a/src/lib/electron/ipc.ts
+++ b/src/lib/electron/ipc.ts
@@ -1,6 +1,7 @@
 import electron, { Menu, MenuItemConstructorOptions } from 'electron';
 import { MenuBarItem, MenuBarSections, MainEvents, RendererEvents } from '../ipc-interface';
 import { defaultIpcMain } from '../ipc';
+import { keys } from '../std';
 
 export type ElectronMenuItem = {
   type: 'callback';
@@ -131,7 +132,7 @@ const menuLookup: MenuLookup = {
 const untypedMenu: { [K: string]: { [S: string]: ElectronMenuItem[]; } } = menuLookup;
 
 const renderMenu = () => {
-  const template = Object.keys(menuLookup).map((menuLabel): MenuItemConstructorOptions => {
+  const template = keys(menuLookup).map((menuLabel): MenuItemConstructorOptions => {
     const submenu: MenuItemConstructorOptions[] = [];
     Object.keys(untypedMenu[menuLabel]).forEach((section, i) => {
       if (i !== 0) {
@@ -157,7 +158,11 @@ const renderMenu = () => {
     });
 
     return {
-      label: menuLabel,
+      // On MacOS, this is done automatically. For consistency across operating systems we do this explicitly
+      // MacOS explicitly shows the application name as the first menu
+      // https://stackoverflow.com/questions/41551110/unable-to-override-app-name-on-mac-os-electron-menu
+      // provides a bit more info although it is not really related to this
+      label: menuLabel === 'Application' ? electron.app.getName() : menuLabel,
       submenu,
     };
   });

--- a/src/lib/framework/manager.ts
+++ b/src/lib/framework/manager.ts
@@ -142,6 +142,8 @@ class Manager {
         `Unable to load previously opened project information. ` +
         `Opening blank project instead. Error message:` + result.message,
       );
+    } else if (result.type === 'not-found') {
+      logger.info('Past project information not found. Opening a blank project!');
     } else {
       pastProject = result.decoded;
     }

--- a/src/lib/framework/menu.ts
+++ b/src/lib/framework/menu.ts
@@ -27,6 +27,12 @@ export const context: ContextFunction = (opts) => {
     items = [...opts.items, null, ...defaultItems];
   }
 
+  // OK so this is important because in the main process we show a default context menu when we don't prevent it here
+  // This is especially important because, on Windows, no menu will show if this function and does not prevent the other
+  // event handler from running!!
+  opts.position.preventDefault();
+  opts.position.stopImmediatePropagation();
+
   ipcSender.send('showMenu', transformMenuOptionsAndSaveCallback({
     ...opts,
     items,

--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -69,6 +69,10 @@ export interface DecodeSuccess<T> {
   decoded: T;
 }
 
+export interface NotFound {
+  type: 'not-found';
+}
+
 export interface Error {
   type: 'error';
   message: string;
@@ -124,11 +128,10 @@ export const write = <T>(type: t.Type<T>, opts: { data: T, path: string }): Erro
   };
 };
 
-export const read = <T>(type: t.Type<T>, opts: { path: string }): DecodeSuccess<T> | Error => {
+export const read = <T>(type: t.Type<T>, opts: { path: string }): DecodeSuccess<T> | NotFound | Error => {
   if (!fs.existsSync(opts.path)) {
     return {
-      type: 'error',
-      message: `${opts.path} does not exist.`,
+      type: 'not-found',
     };
   }
 

--- a/src/lib/ipc-interface.ts
+++ b/src/lib/ipc-interface.ts
@@ -29,6 +29,8 @@ export type MenuBarItem<K extends keyof MenuBarSections> = MenuItem & {
 export interface ElectronMenuPosition {
   x: number;
   y: number;
+  preventDefault: () => void;
+  stopImmediatePropagation: () => void;
 }
 
 export interface ElectronMenuOptions {

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -126,6 +126,18 @@ export const log = (message: LogMessage) => {
     eLog!.transports.console.level = false;
     eLog!.transports.file.level = 'warn';
     eLog!.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] {text}';
+    eLog!.catchErrors({
+      showDialog: false,
+      onError: (e) => {
+        log({
+          level: 'error',
+          message: e.message,
+          name: 'Unhandled',
+          setLevel: 'info',
+          args: [],
+        });
+      },
+    });
   }
 
   eLog![message.level](messageString, ...message.args);
@@ -133,5 +145,3 @@ export const log = (message: LogMessage) => {
   // tslint:disable-next-line:no-console
   console.log(`%c${messageString}`, styleString, ...message.args);
 };
-
-

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -120,6 +120,7 @@ export const log = (message: LogMessage) => {
   const styleString = styleArray.join('; ');
   const messageString = `[${message.name}] ${message.level.toUpperCase()}: ${message.message}`;
 
+  // We do this because if we try to import electron-log while testing the tests fail silently
   if (!eLog) {
     eLog = require('electron-log');
     eLog!.transports.console.level = false;
@@ -127,7 +128,7 @@ export const log = (message: LogMessage) => {
     eLog!.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] {text}';
   }
 
-  eLog![message.level](messageString, message.args);
+  eLog![message.level](messageString, ...message.args);
 
   // tslint:disable-next-line:no-console
   console.log(`%c${messageString}`, styleString, ...message.args);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,7 +38,7 @@ const middleware = () => {
   });
 
   const extensions = require.context(
-    './/extra',
+    './extra',
     // Whether or not to look in subfolders
     true,
     /^.+\.ts/,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,9 @@ const middleware = () => {
 
   extensions.keys().forEach((fileNameOrFolderName) => {
     // slice(1) to remove "."
-    const parts = fileNameOrFolderName.split(path.sep).slice(1);
+    // OK so I initially used path.sep to split the path *but* it wasn't working on windows
+    // IDK why but on windows "/" is still used as the seperator
+    const parts = fileNameOrFolderName.split('/').slice(1);
 
     let extensionModule: any;
     switch (parts.length) {


### PR DESCRIPTION
Issues fixed:
- "extra" extensions on Windows were not being loaded
- Custom context menus were not showing
- The menubar was not showing

Also:
- Added logging in the main process
- Made it so "DAWG" will show up instead of "Application" as the first menubar menu on Windows and Linux
- Made it so errors weren't being logged when files didn't exist